### PR TITLE
Minor fix to be python 3.9 compliant

### DIFF
--- a/crm/crm_approx.py
+++ b/crm/crm_approx.py
@@ -137,7 +137,7 @@ class ApproxProcess:
         p_x: Callable,
         n_grids: int = 1001,
         g_x: Callable = None,  # noqa: RUF013
-        kappa: float | None = None,
+        kappa: Optional[float] = None,
         edges: np.ndarray = None,
         thr: float = 0.8,
         bounds: tuple[float, float] = (0, 1),

--- a/crm/crm_approx.py
+++ b/crm/crm_approx.py
@@ -378,6 +378,8 @@ class ApproxProcess:
                         )
                         new_csum = reverse_cumsum(p_1) + self.c_sum[-1]
                         self.g_x_vals = np.concatenate((fun_eval_1[:-1], self.g_x_vals))
+                    else:
+                        break
                 elif self.find_kappa():
                     extrapolated_grid = self._get_grid_extrapolated_left(
                         bin_pdf, self.kappa, max_arrival_time
@@ -394,6 +396,8 @@ class ApproxProcess:
                         )
                         new_csum = reverse_cumsum(p_1) + self.c_sum[-1]
                         self.g_x_vals = np.concatenate((const_1[:-1], self.g_x_vals))
+                    else:
+                        break
                 else:
                     # This is the case where the kappa is not found, and we have to use trapezoidal rule
                     n = int(np.ceil((max_arrival_time - self.c_sum[-1]) / bin_pdf))
@@ -413,6 +417,8 @@ class ApproxProcess:
                         )
                         new_csum = reverse_cumsum(quadrature) + self.c_sum[-1]
                         self.f_x_vals = np.concatenate((vals[:-1], self.f_x_vals))
+                    else:
+                        break
 
                 self.edges = np.concatenate((extrapolated_grid[:-1], self.edges))
                 self.c_sum = np.concatenate((self.c_sum, new_csum))


### PR DESCRIPTION
Just a minor fix to change `kappa: float | None` to `kappa: Optional[float]` in `crm/crm_approx.py`. The notation `float | None` syntax seems to be supported in python 3.10 or later and in python 3.9.x a `TypeError` is raised.

Hope it helps! :wink: 